### PR TITLE
Adds feature for explicitly vendoring libuv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ links = "uv"
 travis-ci = { repository = "bmatcuk/libuv-sys" }
 maintenance = { status = "actively-developed" }
 
+[features]
+
+vendored-cmake = [ "cmake" ]
+
 [build-dependencies]
 bindgen = "0.54"
 cc = "1.0"
 pkg-config = "0.3.17"
+cmake = { optional = true, version = "0.1.45" }


### PR DESCRIPTION
This change introduces new feature `vendored-cmake` that allows users to
explicitly opt into building and vendoring libuv at compile time.
This is useful in cases where you want the final application to be
better isolated from system dependencies.

The existing behavior (searching for the library via pkg-config and then
building it if not found) is left as the default.

This introduces an optional dependency on cmake.